### PR TITLE
텔레그램 봇 기능 추가

### DIFF
--- a/background.js
+++ b/background.js
@@ -14,7 +14,7 @@ function playSound() {
 function sendTelegramMessage() {
 	var botToken = localStorage['botToken'];
 	var chatId = localStorage['chatId'];
-	var msg = encodeURI('Succeeded in booking a train ticket.');
+	var msg = encodeURI('Macro has been stopped. Please check your reservation status.');
 	if (botToken != undefined && chatId != undefined) {
 		var url = 'https://api.telegram.org/bot' + botToken + '/sendmessage?chat_id=' + chatId + '&text=' + msg;
 		

--- a/background.js
+++ b/background.js
@@ -11,9 +11,28 @@ function playSound() {
 	audio.play();
 }
 
+function sendTelegramMessage() {
+	var botToken = localStorage['botToken'];
+	var chatId = localStorage['chatId'];
+	var msg = encodeURI('Succeeded in booking a train ticket.');
+	if (botToken != undefined && chatId != undefined) {
+		var url = 'https://api.telegram.org/bot' + botToken + '/sendmessage?chat_id=' + chatId + '&text=' + msg;
+		
+		var xmlhttp = new XMLHttpRequest();
+		xmlhttp.onreadystatechange=function() {
+			if (xmlhttp.readyState==4 && xmlhttp.status==200) {
+				var response = xmlhttp.responseText; //if you need to do something with the returned value
+			}
+		}
+		xmlhttp.open('GET', url, true);
+		xmlhttp.send();
+	}
+}
+
 chrome.extension.onMessage.addListener(function(message, sender, sendResponse) {
     if (message && message.type == 'playSound') {
         playSound();
+		sendTelegramMessage();
         sendResponse(true);
     }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -20,5 +20,9 @@
   },
   "web_accessible_resources": [
     "inject.js", "images/btn_start.png", "images/btn_stop.png", "assets/tada.mp3"
-  ]
+  ],
+  "options_ui": {
+    "page": "options.html",
+	"chrome_style": true
+  }
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>SRT Macro Options</title>
+  <style>
+    body: { padding: 10px; }
+  </style>
+</head>
+
+<body>
+  <table cellpadding="5">
+    <tr>
+	  <td align="right">Bot Token:</td>
+	  <td><input type="text" id="bot_token" size="30"/></td>
+	</tr>
+	<tr>
+	  <td align="right">Your Telegram Chat ID:</td>
+	  <td><input type="text" id="chat_id" size="30"/></td>
+	</tr>
+  </table>
+  
+  <br />
+  
+  <div id="status"></div>
+  <button id="save">Save</button>
+
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,41 @@
+var defaultBotToken = 'Set your telegram bot token';
+var defaultChatId = 'Set your telegram chat id';
+
+function save_options() {
+  localStorage['botToken'] = document.getElementById('bot_token').value;
+  localStorage['chatId'] = document.getElementById('chat_id').value;  
+  
+  var url = 'https://api.telegram.org/bot' + document.getElementById('bot_token').value + '/sendmessage?chat_id=' + document.getElementById('chat_id').value + '&text=' + encodeURI('Bot connected.');
+		
+  var xmlhttp = new XMLHttpRequest();
+  xmlhttp.onreadystatechange=function() {
+	  if (xmlhttp.readyState==4 && xmlhttp.status==200) {
+		  var response = xmlhttp.responseText; //if you need to do something with the returned value
+      }
+  }
+  xmlhttp.open('GET', url, true);
+  xmlhttp.send();
+  
+  var status = document.getElementById('status');
+    status.textContent = 'Options saved.';
+    setTimeout(function() {
+      status.textContent = '';
+    }, 750);
+}
+
+function restore_options() {
+  var botToken = localStorage['botToken'];
+  var chatId = localStorage['chatId'];
+  
+  if (botToken == undefined)
+	botToken = defaultBotToken;
+  
+  if (chatId == undefined)
+    chatId = defaultChatId;
+  
+  document.getElementById('bot_token').value = botToken;
+  document.getElementById('chat_id').value = chatId;
+}
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click',
+    save_options);


### PR DESCRIPTION
- 확장 프로그램의 '옵션'에서 텔레그램 봇의 토큰(token)과 본인의 chat id 설정 가능, 설정 저장 시 'Bot connected.' 라는 메시지가 봇에게 전달됨
- 예약 완료 시 트럼펫 소리와 함께 텔레그램 봇으로 예약 완료 알림 전달
- bot token, chat id를 설정하지 않았을 경우 기존과 동일